### PR TITLE
Move error-handling-related ffi decl to proper file

### DIFF
--- a/error_handling.lua
+++ b/error_handling.lua
@@ -182,6 +182,12 @@ local functions_list = {
     'zetac'
 }
 
+-- Link to torch_merr.c error reporting
+ffi.cdef[[
+    int merror;
+    char errtxt[100];
+]]
+
 local function create_wrapper(name)
 
     local function wrapper(...)

--- a/init.lua
+++ b/init.lua
@@ -3,12 +3,6 @@ local ffi = require("ffi")
 cephes = {}
 cephes.ffi = ffi.load(package.searchpath('libcephes', package.cpath))
 
--- Link to torch_merr.c error reporting
-ffi.cdef[[
-    int merror;
-    char errtxt[100];
-]]
-
 -- Define cmplx struct
 ffi.cdef[[
 typedef struct


### PR DESCRIPTION
Just realized that `ffi.cdef` are shared amongst all ffi objects: there is
only one declaration space, regardless of whether ffi is local.
