### PR TITLE
Allow user to control the error reporting

### DIFF
--- a/doc/torchonly.markdown
+++ b/doc/torchonly.markdown
@@ -48,9 +48,9 @@ However, the user can ask Cephes to generate lua errors with the following funct
 Sets the level of error reporting.
 
 ><b>Input:</b>  `level` : can be any of
->   - 'off'/`false`/`0` to be entirely quiet
->   - 'error'/`true`/1 to issue Lua errors with stack trace
->   - 'warning'/'warn'/2 to print a warning on stdout
+>   - `'off'`/`0` to be entirely quiet
+>   - `'error'`/`1` to issue Lua errors with stack trace
+>   - `'warning'`/`2` to print a warning on stdout
 >
 ><b>Returns:</b> None
 

--- a/error_handling.lua
+++ b/error_handling.lua
@@ -6,14 +6,14 @@ local reportError = 0
 -- Do we report error?
 -- can be 'off'/false/0, 'error'/true/1, 'warning'/'warn'/2
 function cephes.setErrorLevel(level)
-    if level == 1 or level == true or level == 'true'  then
-        reportError = 1
-    elseif level == 0 or level == false or level == 'error' or level == 'off' then
+    if level == 0 or level == 'off'  then
         reportError = 0
+    elseif level == 1 or level == 'err' or level == 'error' then
+        reportError = 1
     elseif level == 2 or level == 'warn' or level == 'warning' then
         reportError = 2
     else
-        error("Unknown error level, please choose 'error'/true, 'warning', 'off'/false")
+        error("Unknown error level, please choose 'off'/0, 'err'/'error'/1, 'warning'/'warn'/2")
     end
 end
 

--- a/tests/testErrorHandling.lua
+++ b/tests/testErrorHandling.lua
@@ -11,9 +11,9 @@ end
 function errTest.testError()
     local df = 4
     local previousLevel = cephes.getErrorLevel()
-    cephes.setErrorLevel(0)
+    cephes.setErrorLevel('off')
     tester:assert(function() cephes.chdtr(-1,1) end)
-    cephes.setErrorLevel(1)
+    cephes.setErrorLevel('error')
     tester:assertError(function() cephes.chdtr(-1,1) end)
     cephes.setErrorLevel(previousLevel)
 end


### PR DESCRIPTION
By default, do not issue any error. Can increase to warning, and to error.
